### PR TITLE
fix: 시간 표시 KST(UTC+9) 기준으로 변경

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -14,7 +14,7 @@ db.exec(`
     image_url TEXT,
     price INTEGER,
     sale_price INTEGER,
-    created_at TEXT DEFAULT (datetime('now', 'localtime'))
+    created_at TEXT DEFAULT (datetime('now', '+9 hours'))
   );
 
   CREATE TABLE IF NOT EXISTS rankings (
@@ -22,7 +22,7 @@ db.exec(`
     product_id INTEGER NOT NULL,
     category TEXT NOT NULL,
     rank INTEGER,
-    crawled_at TEXT DEFAULT (datetime('now', 'localtime')),
+    crawled_at TEXT DEFAULT (datetime('now', '+9 hours')),
     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
   );
 `);

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -32,7 +32,7 @@ router.get("/rankings/stats", (req, res) => {
         SELECT date(crawled_at) AS d, MIN(rank) AS best_rank
         FROM rankings
         WHERE product_id = ? AND category = ? AND rank IS NOT NULL
-          AND date(crawled_at) >= date('now', '-7 days')
+          AND date(crawled_at) >= date('now', '+9 hours', '-7 days')
         GROUP BY d
       )
     `).get(p.id, category);
@@ -43,8 +43,8 @@ router.get("/rankings/stats", (req, res) => {
         SELECT date(crawled_at) AS d, MIN(rank) AS best_rank
         FROM rankings
         WHERE product_id = ? AND category = ? AND rank IS NOT NULL
-          AND date(crawled_at) >= date('now', '-14 days')
-          AND date(crawled_at) < date('now', '-7 days')
+          AND date(crawled_at) >= date('now', '+9 hours', '-14 days')
+          AND date(crawled_at) < date('now', '+9 hours', '-7 days')
         GROUP BY d
       )
     `).get(p.id, category);


### PR DESCRIPTION
## Summary

- **[#1]** UTC+0으로 표시되던 시간을 KST(UTC+9) 기준으로 수정

---

## Issues

### [#1] utc-0 기준으로 시간이 표시됨

**Changes**

- `backend/src/db.js`: `datetime('now', 'localtime')` → `datetime('now', '+9 hours')`
- `backend/src/routes/dashboard.js`: `date('now', ...)` 비교 쿼리에 `+9 hours` 오프셋 추가

**Solution**

Railway 배포 서버의 타임존이 UTC로, `localtime`이 UTC 시간을 반환하는 문제.
SQLite의 `+9 hours` modifier를 사용해 저장 및 비교 시 항상 KST 기준으로 동작하도록 수정.

**Related**
- https://github.com/ywoo-park/oliveyoung-tracker/issues/1