### PR TITLE
fix: 전체 카테고리 크롤링 0개 반환 수정

### DIFF
--- a/backend/src/crawler.js
+++ b/backend/src/crawler.js
@@ -85,6 +85,11 @@ async function crawlProductDetail(oliveyoung_id) {
 async function fetchRanking(page, url) {
   await page.goto(url, { waitUntil: "networkidle2", timeout: 30000 });
 
+  await page.waitForFunction(
+    () => document.querySelectorAll("a[href*='goodsNo'][href*='t_number']").length > 0,
+    { timeout: 10000 }
+  ).catch(() => {});
+
   return page.evaluate(() => {
     const result = {};
     document.querySelectorAll("a[href*='goodsNo'][href*='t_number']").forEach((el) => {


### PR DESCRIPTION
## Summary

- 전체 카테고리 크롤링 시 상품이 0개 파싱되는 문제 수정

**Changes**

- `backend/src/crawler.js`: `fetchRanking`에 상품 링크 렌더링 대기 로직 추가

**Solution**

전체 카테고리 페이지는 JS 렌더링이 늦어 `networkidle2` 완료 후에도 상품 목록이 DOM에 없는 경우 발생.
`waitForFunction`으로 상품 링크가 나타날 때까지 최대 10초 대기 후 파싱하도록 수정.