### PR TITLE
debug: 전체 카테고리 크롤링 DOM 디버그 로그 추가

### DIFF
--- a/backend/src/crawler.js
+++ b/backend/src/crawler.js
@@ -86,9 +86,17 @@ async function fetchRanking(page, url) {
   await page.goto(url, { waitUntil: "networkidle2", timeout: 30000 });
 
   await page.waitForFunction(
-    () => document.querySelectorAll("a[href*='goodsNo'][href*='t_number']").length > 0,
-    { timeout: 10000 }
+    () => document.querySelectorAll("a[href*='goodsNo']").length > 0,
+    { timeout: 15000 }
   ).catch(() => {});
+
+  const debug = await page.evaluate(() => {
+    const all = document.querySelectorAll("a[href*='goodsNo']").length;
+    const withRank = document.querySelectorAll("a[href*='goodsNo'][href*='t_number']").length;
+    const sample = document.querySelector("a[href*='goodsNo']")?.getAttribute("href") ?? "없음";
+    return { all, withRank, sample };
+  });
+  console.log(`[Crawler] DOM 확인 - goodsNo 전체: ${debug.all}, t_number 포함: ${debug.withRank}, 샘플: ${debug.sample}`);
 
   return page.evaluate(() => {
     const result = {};


### PR DESCRIPTION
## Summary

- 전체 카테고리 0개 파싱 원인 파악을 위한 디버그 로그 추가

**Changes**

- `backend/src/crawler.js`: `fetchRanking`에 DOM 상태 로그 추가
  - `a[href*='goodsNo']` 전체 개수
  - `a[href*='goodsNo'][href*='t_number']` 개수
  - 첫 번째 링크 샘플 출력