### PR TITLE
fix: 전체 카테고리 크롤링 정상화 (디버그 로그 제거)

### DIFF
--- a/backend/src/crawler.js
+++ b/backend/src/crawler.js
@@ -90,14 +90,6 @@ async function fetchRanking(page, url) {
     { timeout: 15000 }
   ).catch(() => {});
 
-  const debug = await page.evaluate(() => {
-    const all = document.querySelectorAll("a[href*='goodsNo']").length;
-    const withRank = document.querySelectorAll("a[href*='goodsNo'][href*='t_number']").length;
-    const sample = document.querySelector("a[href*='goodsNo']")?.getAttribute("href") ?? "없음";
-    return { all, withRank, sample };
-  });
-  console.log(`[Crawler] DOM 확인 - goodsNo 전체: ${debug.all}, t_number 포함: ${debug.withRank}, 샘플: ${debug.sample}`);
-
   return page.evaluate(() => {
     const result = {};
     document.querySelectorAll("a[href*='goodsNo'][href*='t_number']").forEach((el) => {


### PR DESCRIPTION
## Summary

- 전체 카테고리 크롤링 정상 동작 확인 후 디버그 로그 제거

**Changes**

- `backend/src/crawler.js`: 디버그 로그 제거

**Root Cause**

`waitForFunction` 조건을 `a[href*='goodsNo'][href*='t_number']` → `a[href*='goodsNo']`로 변경하면서
페이지 로딩 완료 전 파싱하던 타이밍 문제 해결됨.