### PR TITLE
랭킹 크롤링 스케줄러 비활성화 / 대시보드 시간대 버그 수정

### DIFF
--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -72,7 +72,7 @@ router.get("/rankings/stats", async (req, res) => {
 // 시간별 순위 (당일/특정일 차트용)
 router.get("/rankings/hourly", async (req, res) => {
   const { category = "전체", date } = req.query;
-  const targetDate = date || new Date().toLocaleDateString("sv-SE");
+  const targetDate = date || new Date().toLocaleString("sv-SE", { timeZone: "Asia/Seoul" }).slice(0, 10);
 
   const { rows } = await pool.query(`
     SELECT p.id AS product_id, p.name, p.oliveyoung_id,

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -1,17 +1,6 @@
-const cron = require("node-cron");
-const { crawlAll } = require("./crawler");
-
-// 매시 10분 실행
+// 랭킹 크롤링 오류 지속으로 스케줄러 비활성화
 function startScheduler() {
-  cron.schedule("*/30 * * * *", async () => {
-    try {
-      await crawlAll();
-    } catch (err) {
-      console.error("[Scheduler] crawlAll 예외:", err.message);
-    }
-  }, { timezone: "Asia/Seoul" });
-
-  console.log("[Scheduler] 스케줄러 시작 (매시 10분)");
+  console.log("[Scheduler] 랭킹 크롤링 스케줄러 비활성화 상태");
 }
 
 module.exports = { startScheduler };


### PR DESCRIPTION
## Summary

- **[scheduler]** 반복적인 크롤링 오류로 인해 30분 주기 랭킹 크롤링 스케줄러 비활성화
- **[dashboard]** 시간별 랭킹 조회 시 날짜 계산에 Asia/Seoul 시간대 명시적 적용

---

## Issues

### [scheduler] 랭킹 크롤링 스케줄러 비활성화

**Changes**

- `backend/src/scheduler.js`: cron 스케줄 제거, `startScheduler()`가 no-op으로 변경

**Solution**

- 지속적인 크롤링 오류로 인해 자동 스케줄 실행 중단
- 수동 크롤링(`POST /api/crawl`)은 유지되어 필요 시 직접 호출 가능

---

### [dashboard] 시간별 랭킹 날짜 시간대 수정

**Changes**

- `backend/src/routes/dashboard.js`: `new Date().toLocaleDateString("sv-SE")` → `new Date().toLocaleString("sv-SE", { timeZone: "Asia/Seoul" }).slice(0, 10)`

**Solution**

- 서버 시스템 시간대에 관계없이 항상 KST 기준 날짜를 사용하도록 수정